### PR TITLE
PG version upgrade to fix typeorm migration run

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
     "multer": "^1.4.2",
-    "pg": "^8.0.0",
+    "pg": "^8.3.0",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.24"
   },


### PR DESCRIPTION
Com base no erro reportado no fórum [Ao executar a migration, não acontece nada](https://app.rocketseat.com.br/h/forum/gostack-11/019e1381-f343-4bfa-be14-d17e84219419?q=migration:run&page=1&filter=all&scope=journey) com a versão do pg 8.0.0 a migration do typeorm não está funcionando. Com a atualização do pg, funciona.