### PR TITLE
pg upgrade version to fix typerom migration:run

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
     "multer": "^1.4.2",
-    "pg": "^8.0.0",
+    "pg": "^8.3.0",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.24"
   },


### PR DESCRIPTION
In Rocketseat forum there are some posts about the error on execute typeorm migration:run like below: 
[Desafio 06: Migrations não criam as tabelas no banco.](https://app.rocketseat.com.br/h/forum/gostack-11/aef014f1-7213-4be7-bf7a-851241173e7f)
[Ao executar a migration, não acontece nada](https://app.rocketseat.com.br/h/forum/gostack-11/019e1381-f343-4bfa-be14-d17e84219419?q=typeorm%20nada&page=7&filter=all&scope=journey)

To fix this problem just upgrade pg version. 